### PR TITLE
Don't stringify and parse the error object to and from json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -192,9 +192,7 @@ export class BufferedChangeset implements IChangeset {
   }
 
   get error() {
-    let obj: Errors<any> = this[ERRORS];
-    // TODO: whyy?
-    return JSON.parse(JSON.stringify(obj));
+    return this[ERRORS];
   }
 
   get data() {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -420,6 +420,19 @@ describe('Unit | Utility | changeset', () => {
     expect(changes).toEqual(expectedChanges);
   });
 
+  it('#set adds a date', () => {
+    const d = new Date();
+    const expectedChanges = [{ key: 'dateOfBirth', value: d }];
+    const dummyChangeset = Changeset(dummyModel);
+    dummyChangeset.set('dateOfBirth', d);
+    const changes = dummyChangeset.changes;
+
+    expect(dummyModel.dateOfBirth).toBeUndefined();
+    expect(dummyChangeset.get('dateOfBirth')).toEqual(d);
+
+    expect(changes).toEqual(expectedChanges);
+  });
+
   it('#set Ember.set works', () => {
     const expectedChanges = [{ key: 'name', value: 'foo' }];
     const dummyChangeset = Changeset(dummyModel);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -433,6 +433,21 @@ describe('Unit | Utility | changeset', () => {
     expect(changes).toEqual(expectedChanges);
   });
 
+  it('#set adds a date if already set on model', () => {
+    const model = { dateOfBirth: new Date() };
+    const dummyChangeset = Changeset(model);
+    const d = new Date('March 25, 1990');
+    dummyChangeset.set('dateOfBirth', d);
+    const changes = dummyChangeset.changes;
+
+    expect(dummyModel.dateOfBirth).toBeUndefined();
+    expect(dummyChangeset.get('dateOfBirth')).toEqual(d);
+    expect(dummyChangeset.dateOfBirth).toEqual(d);
+
+    const expectedChanges = [{ key: 'dateOfBirth', value: d }];
+    expect(changes).toEqual(expectedChanges);
+  });
+
   it('#set Ember.set works', () => {
     const expectedChanges = [{ key: 'name', value: 'foo' }];
     const dummyChangeset = Changeset(dummyModel);


### PR DESCRIPTION
Stringifying and parsing again will throw when `obj` has a circular
structure which can exist when e.g. ember data relationships are values
in the changesets underlying object. Fixes #19